### PR TITLE
Add expandable footer links behind See more button

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,8 +200,10 @@
     </footer>
 
     <div class="sub-footer">
-        &copy; Copyright 2024 | Developed by
-        <a href="https://SaasProductized.com" target="_blank">Saas Productized Co</a>. | All Rights Reserved
+        &copy; Copyright 2024 |
+        <a href="https://eliteclearservices.com" target="_blank">eliteclearservices.com</a>
+        <span id="extra-links" class="hidden"> | Developed by <a href="https://SaasProductized.com" target="_blank">Saas Productized Co</a>. | All Rights Reserved</span>
+        <button id="see-more" class="see-more-btn">See more</button>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/emailjs-com@2/dist/email.min.js"></script>

--- a/script.js
+++ b/script.js
@@ -146,3 +146,13 @@ window.addEventListener('load', adjustNavPosition);
 // Adjust the nav position on window resize
 window.addEventListener('resize', adjustNavPosition);
 
+// Reveal additional footer links on "See more" click
+const seeMoreButton = document.getElementById('see-more');
+const extraLinks = document.getElementById('extra-links');
+if (seeMoreButton && extraLinks) {
+    seeMoreButton.addEventListener('click', () => {
+        extraLinks.classList.remove('hidden');
+        seeMoreButton.style.display = 'none';
+    });
+}
+

--- a/service-area.html
+++ b/service-area.html
@@ -169,8 +169,11 @@
     </footer>
     
     <div class="sub-footer">
-        <p>&copy; Copyright 2024 | Developed by 
-            <a href="https://SaasProductized.com" target="_blank">Saas Productized Co</a>. | All Rights Reserved</p>
+        <p>&copy; Copyright 2024 |
+            <a href="https://eliteclearservices.com" target="_blank">eliteclearservices.com</a>
+            <span id="extra-links-service" class="hidden"> | Developed by <a href="https://SaasProductized.com" target="_blank">Saas Productized Co</a>. | All Rights Reserved</span>
+            <button id="see-more-service" class="see-more-btn">See more</button>
+        </p>
     </div>
 
     <!-- JavaScript to handle shrinking logo and sticky nav -->
@@ -201,6 +204,16 @@
 
         // Adjust the nav position on window resize
         window.addEventListener('resize', adjustNavPosition);
+    </script>
+
+    <script>
+        const seeMoreService = document.getElementById('see-more-service');
+        if (seeMoreService) {
+            seeMoreService.addEventListener('click', function () {
+                document.getElementById('extra-links-service').classList.remove('hidden');
+                seeMoreService.style.display = 'none';
+            });
+        }
     </script>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -408,6 +408,19 @@ footer {
     text-decoration: underline;
 }
 
+.hidden {
+    display: none;
+}
+
+.see-more-btn {
+    background: none;
+    border: none;
+    color: blue;
+    text-decoration: underline;
+    cursor: pointer;
+    font-size: inherit;
+}
+
 /* Google Reviews Section Styling */
 .google-reviews-section {
     padding: 2rem 1rem; /* Reduced padding for less space */


### PR DESCRIPTION
## Summary
- Add a "See more" button after eliteclearservices.com to reveal developer credits.
- Style button and hide extra links by default.
- Hook up JavaScript to toggle hidden footer content.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963e2fb63c83218cbbe3119103fed0