### PR TITLE
Fix service area page contact button

### DIFF
--- a/service-area.html
+++ b/service-area.html
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html#contact" class="cta-button">Contact Us Today</a>
+        <a href="index.html#contact-form" class="cta-button">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->


### PR DESCRIPTION
## Summary
- Link "Contact Us Today" button on service area page directly to `#contact-form` so users land at the top of the form

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6896431e9eb08321905eb78fadfdff4d