### PR TITLE
Fix service area contact button link

### DIFF
--- a/service-area.html
+++ b/service-area.html
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html#contact" class="cta-button">Contact Us Today</a>
+        <a href="/index.html#contact" class="cta-button">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->


### PR DESCRIPTION
## Summary
- Ensure "Contact Us Today" button on service-area page directs to contact form via absolute path.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896451072248321bd25914872a37c01