### PR TITLE
Fix contact link redirection from service area page

### DIFF
--- a/service-area.html
+++ b/service-area.html
@@ -68,7 +68,7 @@
                 <li><a href="index.html#hero">Home</a></li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html?contact">Contact</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
             </ul>
         </nav>
     </header>
@@ -81,7 +81,7 @@
                 <i class="fas fa-phone"></i>
             </div>
         </a>
-        <a href="index.html?contact" class="btn">Get a Free Quote</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
     </div>
     <br>
     <br>
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html?contact" class="cta-button">Contact Us Today</a>
+        <a href="index.html#contact" class="cta-button">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->


### PR DESCRIPTION
## Summary
- Ensure all service area links point directly to the contact section using `#contact`

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689661fb609c832193b081399a0c0033