### PR TITLE
Fix contact links to scroll to contact section

### DIFF
--- a/script.js
+++ b/script.js
@@ -135,17 +135,21 @@ function scrollToTarget() {
     const params = new URLSearchParams(window.location.search);
     let selector = window.location.hash;
 
-    // Support query parameter (?contact) for cross-page navigation
+    // Support query parameter (?contact) for cross-page navigation by converting it to a hash
     if (!selector && params.has('contact')) {
         selector = '#contact';
+        history.replaceState(null, '', '#contact');
     }
 
     if (selector) {
         const target = document.querySelector(selector);
         if (target) {
-            const offset = nav.offsetHeight + logoContainer.offsetHeight; // Total header height
-            const yOffset = target.getBoundingClientRect().top + window.pageYOffset - offset;
-            window.scrollTo({ top: yOffset, behavior: 'smooth' });
+            // Wait for layout to stabilize, then account for the fixed header height
+            requestAnimationFrame(() => {
+                const offset = nav.offsetHeight + logoContainer.offsetHeight;
+                const yOffset = target.getBoundingClientRect().top + window.pageYOffset - offset;
+                window.scrollTo({ top: yOffset, behavior: 'smooth' });
+            });
         }
     }
 }

--- a/service-area.html
+++ b/service-area.html
@@ -68,7 +68,7 @@
                 <li><a href="index.html#hero">Home</a></li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html?contact">Contact</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
             </ul>
         </nav>
     </header>
@@ -81,7 +81,7 @@
                 <i class="fas fa-phone"></i>
             </div>
         </a>
-        <a href="index.html?contact" class="btn">Get a Free Quote</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
     </div>
     <br>
     <br>
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html?contact" class="cta-button">Contact Us Today</a>
+        <a href="index.html#contact" class="cta-button">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->


### PR DESCRIPTION
## Summary
- point service area navigation and buttons to `#contact`
- convert `?contact` queries to hash and offset scroll after layout

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966654d170832193a583b9c709e29d