### PR TITLE
Ensure cross-page contact links point to contact form

### DIFF
--- a/service-area.html
+++ b/service-area.html
@@ -68,7 +68,7 @@
                 <li><a href="index.html#hero">Home</a></li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#contact">Contact</a></li>
+                <li><a href="index.html?contact">Contact</a></li>
             </ul>
         </nav>
     </header>
@@ -81,7 +81,7 @@
                 <i class="fas fa-phone"></i>
             </div>
         </a>
-        <a href="index.html#contact" class="btn">Get a Free Quote</a>
+        <a href="index.html?contact" class="btn">Get a Free Quote</a>
     </div>
     <br>
     <br>
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html#contact" class="cta-button">Contact Us Today</a>
+        <a href="index.html?contact" class="cta-button">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->


### PR DESCRIPTION
## Summary
- Ensure Service Area navigation "Contact" link opens contact form on the homepage
- Update Service Area "Get a Free Quote" and "Contact Us Today" buttons to direct to the homepage's contact form

## Testing
- `npm test` *(fails: ENOENT, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896707b0f9483218c6c9f9cc319e917