### PR TITLE
Fix cross-page contact navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -147,7 +147,10 @@ function scrollToTarget() {
             // Wait for layout to stabilize, then account for the fixed header height
             requestAnimationFrame(() => {
                 const offset = nav.offsetHeight + logoContainer.offsetHeight;
-                const yOffset = target.getBoundingClientRect().top + window.pageYOffset - offset;
+                // Use the element's offset from the top of the document to
+                // avoid issues when navigating from another page where the
+                // browser may have already adjusted the scroll position.
+                const yOffset = target.offsetTop - offset;
                 window.scrollTo({ top: yOffset, behavior: 'smooth' });
             });
         }

--- a/service-area.html
+++ b/service-area.html
@@ -68,7 +68,7 @@
                 <li><a href="index.html#hero">Home</a></li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html?contact">Contact</a></li>
+                <li><a href="index.html#contact" class="contact-link">Contact</a></li>
             </ul>
         </nav>
     </header>
@@ -81,7 +81,7 @@
                 <i class="fas fa-phone"></i>
             </div>
         </a>
-        <a href="index.html?contact" class="btn">Get a Free Quote</a>
+        <a href="index.html#contact" class="btn contact-link">Get a Free Quote</a>
     </div>
     <br>
     <br>
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html?contact" class="cta-button">Contact Us Today</a>
+        <a href="index.html#contact" class="cta-button contact-link">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->
@@ -201,6 +201,14 @@
 
         // Adjust the nav position on window resize
         window.addEventListener('resize', adjustNavPosition);
+
+        // Manually redirect contact-related links to the contact form on index.html
+        document.querySelectorAll('.contact-link').forEach(link => {
+            link.addEventListener('click', function (e) {
+                e.preventDefault();
+                window.location.href = 'index.html#contact';
+            });
+        });
     </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Update service area contact links and buttons to point directly to the contact section on index.html and add manual redirect logic
- Ensure scroll logic uses element offset to reliably land on the contact form from external pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689672fdeb508321a338ac6767c20a16