### PR TITLE
Fix cross-page navigation to contact form

### DIFF
--- a/script.js
+++ b/script.js
@@ -171,6 +171,19 @@ window.addEventListener('scroll', function () {
 window.addEventListener('load', () => {
     adjustNavPosition();
     scrollToTarget();
+
+    // The reviews widget injected by Elfsight loads its content asynchronously and can
+    // shift the page after the initial scroll calculation. Observe the widget container
+    // and re-run the scroll once it populates to ensure the contact form is positioned
+    // correctly when navigating from other pages.
+    const elfsightContainer = document.querySelector('[class^="elfsight-app-"]');
+    if (elfsightContainer) {
+        const observer = new MutationObserver(() => {
+            scrollToTarget();
+            observer.disconnect();
+        });
+        observer.observe(elfsightContainer, { childList: true, subtree: true });
+    }
 });
 
 // Re-adjust scroll position when the hash changes (e.g., internal navigation links)

--- a/service-area.html
+++ b/service-area.html
@@ -68,7 +68,7 @@
                 <li><a href="index.html#hero">Home</a></li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html#contact" class="contact-link">Contact</a></li>
+                <li><a href="index.html?contact" class="contact-link">Contact</a></li>
             </ul>
         </nav>
     </header>
@@ -81,7 +81,7 @@
                 <i class="fas fa-phone"></i>
             </div>
         </a>
-        <a href="index.html#contact" class="btn contact-link">Get a Free Quote</a>
+        <a href="index.html?contact" class="btn contact-link">Get a Free Quote</a>
     </div>
     <br>
     <br>
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html#contact" class="cta-button contact-link">Contact Us Today</a>
+        <a href="index.html?contact" class="cta-button contact-link">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->


### PR DESCRIPTION
## Summary
- Update service-area page links to explicitly target the contact section on index with a query parameter
- Re-scroll to the contact form after the Elfsight reviews widget loads so navigation lands in the right spot

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689676b23f34832195b0e6c30871bd01