### PR TITLE
Fix contact navigation redirect

### DIFF
--- a/script.js
+++ b/script.js
@@ -90,39 +90,42 @@ const carouselImages = document.querySelectorAll('.carousel-img');
 const leftArrow = document.querySelector('.left-arrow');
 const rightArrow = document.querySelector('.right-arrow');
 
-// Set initial index and image width
-let currentIndex = 0;
-const totalImages = carouselImages.length;
-const imagesToShow = 3;
-let imageWidth = carouselImages[0].clientWidth + 20;
+// Initialize carousel only if images are present
+if (carousel && carouselImages.length > 0 && leftArrow && rightArrow) {
+    // Set initial index and image width
+    let currentIndex = 0;
+    const totalImages = carouselImages.length;
+    const imagesToShow = 3;
+    let imageWidth = carouselImages[0].clientWidth + 20;
 
-// Right arrow click event
-rightArrow.addEventListener('click', () => {
-    if (currentIndex < totalImages - imagesToShow) {
-        currentIndex++;
-        updateCarousel();
+    // Right arrow click event
+    rightArrow.addEventListener('click', () => {
+        if (currentIndex < totalImages - imagesToShow) {
+            currentIndex++;
+            updateCarousel();
+        }
+    });
+
+    // Left arrow click event
+    leftArrow.addEventListener('click', () => {
+        if (currentIndex > 0) {
+            currentIndex--;
+            updateCarousel();
+        }
+    });
+
+    // Function to update the carousel's position
+    function updateCarousel() {
+        const newTransformValue = -currentIndex * imageWidth;
+        carousel.style.transform = `translateX(${newTransformValue}px)`;
     }
-});
 
-// Left arrow click event
-leftArrow.addEventListener('click', () => {
-    if (currentIndex > 0) {
-        currentIndex--;
+    // Update image width on window resize to ensure responsiveness
+    window.addEventListener('resize', () => {
+        imageWidth = carouselImages[0].clientWidth + 20;
         updateCarousel();
-    }
-});
-
-// Function to update the carousel's position
-function updateCarousel() {
-    const newTransformValue = -currentIndex * imageWidth;
-    carousel.style.transform = `translateX(${newTransformValue}px)`;
+    });
 }
-
-// Update image width on window resize to ensure responsiveness
-window.addEventListener('resize', () => {
-    imageWidth = carouselImages[0].clientWidth + 20;
-    updateCarousel();
-});
 
 // Function to adjust the navigation bar's position under the logo
 function adjustNavPosition() {

--- a/service-area.html
+++ b/service-area.html
@@ -201,14 +201,6 @@
 
         // Adjust the nav position on window resize
         window.addEventListener('resize', adjustNavPosition);
-
-        // Manually redirect contact-related links to the contact form on index.html
-        document.querySelectorAll('.contact-link').forEach(link => {
-            link.addEventListener('click', function (e) {
-                e.preventDefault();
-                window.location.href = 'index.html#contact';
-            });
-        });
     </script>
 
 </body>


### PR DESCRIPTION
## Summary
- Prevent script errors by only initializing the carousel when images exist
- Remove extra contact-link redirect logic so service-area links send users to the contact form on the index page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896794e02a08321b95b0400c3b2822d