### PR TITLE
Stabilize contact anchors and reviews layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,9 +120,11 @@
     </section>
 
     <section id="reviews" class="reviews-section">
-        <!-- Elfsight All-in-One Reviews | Untitled All-in-One Reviews -->
-        <script src="https://static.elfsight.com/platform/platform.js" async></script>
-        <div class="elfsight-app-66843417-1374-4849-b046-19c440d64067" data-elfsight-app-lazy></div>
+        <div class="reviews-widget">
+            <!-- Elfsight All-in-One Reviews | Untitled All-in-One Reviews -->
+            <script src="https://static.elfsight.com/platform/platform.js" async></script>
+            <div class="elfsight-app-66843417-1374-4849-b046-19c440d64067" data-elfsight-app-lazy></div>
+        </div>
     </section>
 
     <section id="about" class="about-section">

--- a/script.js
+++ b/script.js
@@ -90,71 +90,46 @@ const carouselImages = document.querySelectorAll('.carousel-img');
 const leftArrow = document.querySelector('.left-arrow');
 const rightArrow = document.querySelector('.right-arrow');
 
-// Set initial index and image width
-let currentIndex = 0;
-const totalImages = carouselImages.length;
-const imagesToShow = 3;
-let imageWidth = carouselImages[0].clientWidth + 20;
+// Initialize carousel only if elements exist
+if (carousel && carouselImages.length > 0 && leftArrow && rightArrow) {
+    let currentIndex = 0;
+    const totalImages = carouselImages.length;
+    const imagesToShow = 3;
+    let imageWidth = carouselImages[0].clientWidth + 20;
 
-// Right arrow click event
-rightArrow.addEventListener('click', () => {
-    if (currentIndex < totalImages - imagesToShow) {
-        currentIndex++;
-        updateCarousel();
+    // Right arrow click event
+    rightArrow.addEventListener('click', () => {
+        if (currentIndex < totalImages - imagesToShow) {
+            currentIndex++;
+            updateCarousel();
+        }
+    });
+
+    // Left arrow click event
+    leftArrow.addEventListener('click', () => {
+        if (currentIndex > 0) {
+            currentIndex--;
+            updateCarousel();
+        }
+    });
+
+    // Function to update the carousel's position
+    function updateCarousel() {
+        const newTransformValue = -currentIndex * imageWidth;
+        carousel.style.transform = `translateX(${newTransformValue}px)`;
     }
-});
 
-// Left arrow click event
-leftArrow.addEventListener('click', () => {
-    if (currentIndex > 0) {
-        currentIndex--;
+    // Update image width on window resize to ensure responsiveness
+    window.addEventListener('resize', () => {
+        imageWidth = carouselImages[0].clientWidth + 20;
         updateCarousel();
-    }
-});
-
-// Function to update the carousel's position
-function updateCarousel() {
-    const newTransformValue = -currentIndex * imageWidth;
-    carousel.style.transform = `translateX(${newTransformValue}px)`;
+    });
 }
-
-// Update image width on window resize to ensure responsiveness
-window.addEventListener('resize', () => {
-    imageWidth = carouselImages[0].clientWidth + 20;
-    updateCarousel();
-});
 
 // Function to adjust the navigation bar's position under the logo
 function adjustNavPosition() {
     const logoHeight = logoContainer.offsetHeight;
     nav.style.top = `${logoHeight}px`; // Dynamically adjust nav based on logo container height
-}
-
-// Scroll to the section specified in the URL hash or query parameter
-function scrollToTarget() {
-    const params = new URLSearchParams(window.location.search);
-    let selector = window.location.hash;
-
-    // Support query parameter (?contact) for cross-page navigation by converting it to a hash
-    if (!selector && params.has('contact')) {
-        selector = '#contact';
-        history.replaceState(null, '', '#contact');
-    }
-
-    if (selector) {
-        const target = document.querySelector(selector);
-        if (target) {
-            // Wait for layout to stabilize, then account for the fixed header height
-            requestAnimationFrame(() => {
-                const offset = nav.offsetHeight + logoContainer.offsetHeight;
-                // Use the element's offset from the top of the document to
-                // avoid issues when navigating from another page where the
-                // browser may have already adjusted the scroll position.
-                const yOffset = target.offsetTop - offset;
-                window.scrollTo({ top: yOffset, behavior: 'smooth' });
-            });
-        }
-    }
 }
 
 // Scroll event handler to adjust logo size and navigation
@@ -167,27 +142,8 @@ window.addEventListener('scroll', function () {
     adjustNavPosition(); // Reposition the nav on scroll
 });
 
-// Adjust the nav position on page load and ensure links land correctly
-window.addEventListener('load', () => {
-    adjustNavPosition();
-    scrollToTarget();
-
-    // The reviews widget injected by Elfsight loads its content asynchronously and can
-    // shift the page after the initial scroll calculation. Observe the widget container
-    // and re-run the scroll once it populates to ensure the contact form is positioned
-    // correctly when navigating from other pages.
-    const elfsightContainer = document.querySelector('[class^="elfsight-app-"]');
-    if (elfsightContainer) {
-        const observer = new MutationObserver(() => {
-            scrollToTarget();
-            observer.disconnect();
-        });
-        observer.observe(elfsightContainer, { childList: true, subtree: true });
-    }
-});
-
-// Re-adjust scroll position when the hash changes (e.g., internal navigation links)
-window.addEventListener('hashchange', scrollToTarget);
+// Adjust the nav position on page load
+window.addEventListener('load', adjustNavPosition);
 
 // Adjust the nav position on window resize
 window.addEventListener('resize', adjustNavPosition);

--- a/service-area.html
+++ b/service-area.html
@@ -68,7 +68,7 @@
                 <li><a href="index.html#hero">Home</a></li>
                 <li><a href="index.html#about">About</a></li>
                 <li><a href="index.html#services">Services</a></li>
-                <li><a href="index.html?contact" class="contact-link">Contact</a></li>
+                <li><a href="index.html#contact">Contact</a></li>
             </ul>
         </nav>
     </header>
@@ -81,7 +81,7 @@
                 <i class="fas fa-phone"></i>
             </div>
         </a>
-        <a href="index.html?contact" class="btn contact-link">Get a Free Quote</a>
+        <a href="index.html#contact" class="btn">Get a Free Quote</a>
     </div>
     <br>
     <br>
@@ -141,7 +141,7 @@
         </tbody>
     </table>
 
-        <a href="index.html?contact" class="cta-button contact-link">Contact Us Today</a>
+        <a href="index.html#contact" class="cta-button">Contact Us Today</a>
     </div>
 
     <!-- Leaflet.js Map Scripts -->
@@ -202,13 +202,6 @@
         // Adjust the nav position on window resize
         window.addEventListener('resize', adjustNavPosition);
 
-        // Manually redirect contact-related links to the contact form on index.html
-        document.querySelectorAll('.contact-link').forEach(link => {
-            link.addEventListener('click', function (e) {
-                e.preventDefault();
-                window.location.href = 'index.html#contact';
-            });
-        });
     </script>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -636,10 +636,20 @@ p {
 }
 
 /* Reviews section */
+
 .reviews-section {
     background: url('background-image.jpeg') no-repeat center center/cover;
     text-align: center;
     padding: 3rem 1rem;
+    min-height: 600px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.reviews-widget {
+    width: 100%;
+    height: 100%;
 }
 
 .reviews-container {


### PR DESCRIPTION
## Summary
- Wrap Elfsight reviews widget in a dedicated container and give the section a fixed height so anchors land consistently
- Point service-area contact links directly to `#contact` and drop the manual redirect script
- Simplify front-end script by removing cross-page redirect logic and only initializing the carousel when images exist

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896794e02a08321b95b0400c3b2822d