### PR TITLE
Fix delayed nav movement with logo

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,28 +22,11 @@ const nav = document.querySelector('nav');
 const logo = document.querySelector('.logo');
 const header = document.querySelector('header');
 const logoContainer = document.querySelector('.logo-container');
-const heroSection = document.querySelector('#hero');
-
-// Function to handle sticky navigation and logo resizing
-function handleNavPosition() {
-    const heroBottom = heroSection ? heroSection.offsetHeight : 0;
-    const logoHeight = logoContainer.offsetHeight;
-
-    if (window.scrollY >= heroBottom) {
-        nav.classList.add('fixed');
-        logo.classList.add('small');  // Shrink logo when scrolling
-        nav.style.top = `${logoHeight - 30}px`;  // Adjust nav top position when scrolling
-    } else {
-        nav.classList.remove('fixed');
-        logo.classList.remove('small');
-        nav.style.top = `${logoHeight}px`;  // Reset nav position below the full-sized logo
-    }
-}
 
 // Ensure nav links stay visible
 function ensureNavLinkVisibility() {
     navLinks.forEach(link => {
-        link.style.color = 'white';  // Ensure nav links are white
+        link.style.color = 'white';
     });
 }
 
@@ -70,19 +53,22 @@ function highlightNavLink() {
     });
 }
 
-// Call functions on scroll
-window.addEventListener('scroll', () => {
-    handleNavPosition();
-    ensureNavLinkVisibility();  // Make sure links are white on scroll
+// Update header, logo, and active nav links based on scroll
+function updateHeader() {
+    if (window.scrollY > 100) {
+        header.classList.add('sticky');
+        logo.classList.add('small');
+    } else {
+        header.classList.remove('sticky');
+        logo.classList.remove('small');
+    }
+    ensureNavLinkVisibility();
     highlightNavLink();
-});
+}
 
-// Ensure the active section is correct and links are visible on page load
-document.addEventListener('DOMContentLoaded', () => {
-    handleNavPosition();
-    ensureNavLinkVisibility();  // Make sure links are white on load
-    highlightNavLink();
-});
+// Call updateHeader on scroll and when the page loads
+window.addEventListener('scroll', updateHeader);
+document.addEventListener('DOMContentLoaded', updateHeader);
 
 // Select carousel elements
 const carousel = document.querySelector('.carousel-images');
@@ -127,12 +113,6 @@ if (carousel && carouselImages.length > 0 && leftArrow && rightArrow) {
     });
 }
 
-// Function to adjust the navigation bar's position under the logo
-function adjustNavPosition() {
-    const logoHeight = logoContainer.offsetHeight;
-    nav.style.top = `${logoHeight}px`; // Dynamically adjust nav based on logo container height
-}
-
 // Scroll to the section specified in the URL hash
 function scrollToTarget() {
     const selector = window.location.hash;
@@ -149,25 +129,11 @@ function scrollToTarget() {
     }
 }
 
-// Scroll event handler to adjust logo size and navigation
-window.addEventListener('scroll', function () {
-    if (window.scrollY > 100) {
-        header.classList.add('sticky');
-    } else {
-        header.classList.remove('sticky');
-    }
-    adjustNavPosition(); // Reposition the nav on scroll
-});
-
-// Adjust the nav position on page load and ensure links land correctly
+// Adjust scroll position for hash links on load and hash changes
 window.addEventListener('load', () => {
-    adjustNavPosition();
+    updateHeader();
     scrollToTarget();
 });
 
-// Re-adjust scroll position when the hash changes (e.g., internal navigation links)
 window.addEventListener('hashchange', scrollToTarget);
-
-// Adjust the nav position on window resize
-window.addEventListener('resize', adjustNavPosition);
 

--- a/service-area.html
+++ b/service-area.html
@@ -175,32 +175,21 @@
 
     <!-- JavaScript to handle shrinking logo and sticky nav -->
     <script>
-        const logo = document.querySelector('.logo');
-        const nav = document.querySelector('nav');
         const header = document.querySelector('header');
-        const logoContainer = document.querySelector('.logo-container');
+        const logo = document.querySelector('.logo');
 
-        // Function to adjust the navigation bar's position under the logo
-        function adjustNavPosition() {
-            const logoHeight = logoContainer.offsetHeight;
-            nav.style.top = `${logoHeight}px`; // Dynamically adjust nav based on logo container height
-        }
-
-        // Scroll event handler to adjust logo size and navigation
-        window.addEventListener('scroll', function () {
+        function updateHeader() {
             if (window.scrollY > 100) {
                 header.classList.add('sticky');
+                logo.classList.add('small');
             } else {
                 header.classList.remove('sticky');
+                logo.classList.remove('small');
             }
-            adjustNavPosition(); // Reposition the nav on scroll
-        });
+        }
 
-        // Adjust the nav position on page load
-        window.addEventListener('load', adjustNavPosition);
-
-        // Adjust the nav position on window resize
-        window.addEventListener('resize', adjustNavPosition);
+        window.addEventListener('scroll', updateHeader);
+        document.addEventListener('DOMContentLoaded', updateHeader);
     </script>
 
 </body>

--- a/styles.css
+++ b/styles.css
@@ -135,16 +135,14 @@ nav {
     position: fixed;
     top: 150px; /* Position nav under the logo container */
     z-index: 1000; /* Place the nav under the logo */
-    transition: all 0.3s ease;
+    transition: top 0.3s ease;
     box-sizing: border-box;
 }
 
 /* Sticky Navigation - when scrolling */
-nav.fixed {
-    top: 110px; /* Ensure it stays below smaller logo when scrolling */
+.sticky nav {
+    top: 80px; /* Move nav with the smaller logo */
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    background-color: #2c3e50; /* Ensure background color stays consistent */
-    z-index: 1001; /* Ensure it stays above the content */
 }
 
 /* Ensure the navigation links are always visible */
@@ -168,11 +166,6 @@ nav ul li a {
     padding-bottom: 0.5rem;
     border-bottom: 2px solid transparent;
     transition: border-color 0.3s, color 0.3s;
-}
-
-/* Sticky Navigation Link Visibility - fixed class */
-nav.fixed ul li a {
-    color: white !important;  /* Force white color when nav is fixed */
 }
 
 /* Underline the current section being viewed */


### PR DESCRIPTION
## Summary
- tie navigation bar position to header's sticky state via CSS
- simplify scroll logic so nav and logo shrink together
- streamline service area page script to match new behavior

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689683aa7a0083219d45a4cf8222dda2