### PR TITLE
Fix navigation link visibility and adjust hero spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,10 @@
             color: white !important;
         }
 
+        nav ul li a:visited {
+            color: white !important;
+        }
+
         /* Updated text color */
         h2, p, footer, nav ul li a {
             color: #FFFFFF !important; /* Ensure bright white text */

--- a/service-area.html
+++ b/service-area.html
@@ -51,6 +51,10 @@
         nav ul li a {
             color: white !important;
         }
+
+        nav ul li a:visited {
+            color: white !important;
+        }
     </style>
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -60,7 +60,7 @@ section {
     color: white;
     text-align: center;
     padding: 6rem 2rem; /* Increased padding for text content */
-    margin-top: 240px; /* Adjusted margin to account for logo and nav */
+    margin-top: 210px; /* Adjusted margin to account for logo and nav */
 }
 
 /* Adding padding for motto space */
@@ -167,6 +167,10 @@ nav ul li a {
     border-bottom: 2px solid transparent;
     transition: border-color 0.3s, color 0.3s;
     text-shadow: 0 0 3px rgba(0, 0, 0, 0.5); /* Improve visibility on all backgrounds */
+}
+
+nav ul li a:visited {
+    color: white !important;
 }
 
 /* Underline the current section being viewed */


### PR DESCRIPTION
## Summary
- Ensure navigation links remain white even after visiting
- Reduce top margin of hero section to eliminate gray gap beneath navigation

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689687fd157483218ee1fc6803fb31b3