### PR TITLE
Fix navigation bar visibility and contact links

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
             transition: top 0.3s ease;
             position: fixed;
             top: 150px; /* Position nav below the logo container */
-            z-index: 999;
+            z-index: 1003; /* Ensure nav stays above widgets */
         }
 
         nav ul li a {

--- a/script.js
+++ b/script.js
@@ -30,7 +30,8 @@ const contactLinks = document.querySelectorAll('.contact-link');
 // Ensure nav links stay visible
 function ensureNavLinkVisibility() {
     navLinks.forEach(link => {
-        link.style.color = 'white';
+        // Use inline styles with !important so widgets can't override the color
+        link.style.setProperty('color', 'white', 'important');
     });
 }
 
@@ -169,7 +170,10 @@ window.addEventListener('hashchange', scrollToTarget);
 const reviewsWidget = document.querySelector('.reviews-widget');
 if (reviewsWidget) {
     const observer = new MutationObserver(() => {
+        // Widget load can inject styles that hide nav links or shift layout
         scrollToTarget();
+        ensureNavLinkVisibility();
+        highlightNavLink();
         observer.disconnect();
     });
     observer.observe(reviewsWidget, { childList: true, subtree: true });


### PR DESCRIPTION
## Summary
- Raise navigation bar z-index so links stay above third-party widgets
- Force navigation link colors to remain white and reapply after review widget loads

## Testing
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689759adc87483219bc9e223c792e075