### PR TITLE
Fix banner spacing and sub-footer link style

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 
     <div class="sub-footer">
         &copy; Copyright 2024 | Developed by
-        <a href="https://SaasProductized.com" target="_blank">Saas Productized Co</a>. | <br> All Rights Reserved
+        <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br> All Rights Reserved
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/emailjs-com@2/dist/email.min.js"></script>

--- a/service-area.html
+++ b/service-area.html
@@ -112,8 +112,8 @@
     </footer>
     
     <div class="sub-footer">
-        <p>&copy; Copyright 2024 | Developed by 
-            <a href="https://SaasProductized.com" target="_blank">Saas Productized Co</a>. | <br> All Rights Reserved</p>
+        <p>&copy; Copyright 2024 | Developed by
+            <a href="https://SaasProductized.com" target="_blank">SaaS Productized Co.</a> | <br> All Rights Reserved</p>
     </div>
 
     <script src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -85,7 +85,8 @@ section::before {
     color: white;
     text-align: center;
     padding: 6rem 2rem; /* Increased padding for text content */
-    margin-top: 260px; /* Adjusted margin to account for logo and nav */
+    padding-top: calc(6rem + 260px); /* Offset content for fixed header */
+    margin-top: 0; /* Remove gap under navigation */
 }
 
 /* Adding padding for motto space */
@@ -424,8 +425,13 @@ footer {
 }
 
 .sub-footer a {
-    color: blue !important;
-    text-decoration: underline;
+    color: #000 !important;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.sub-footer a:visited {
+    color: #000 !important;
 }
 
 /* Google Reviews Section Styling */
@@ -562,8 +568,9 @@ footer {
 /* Service Area page */
 .service-area-container {
     padding: 2rem; /* General padding for larger screens */
+    padding-top: calc(2rem + 260px); /* Offset content for fixed header */
     max-width: 1000px;
-    margin: 260px auto 2rem; /* Space content below fixed header */
+    margin: 0 auto 2rem; /* Remove top margin to eliminate gap */
     background: rgba(255, 255, 255, 0.9);
     border-radius: 8px;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
@@ -632,6 +639,7 @@ footer {
 @media (max-width: 768px) {
     .service-area-container {
         padding: 1.5rem; /* Reduce padding for smaller screens */
+        padding-top: calc(1.5rem + 260px); /* Offset for fixed header on mobile */
         max-width: 90%; /* Limit the width to make it more centered */
     }
 


### PR DESCRIPTION
## Summary
- remove gray gap under navigation by switching top margins to padding in hero and service-area sections
- style sub-footer link as bold black text and correct "SaaS Productized Co." wording

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68975e55544c8321ad5c741529c16c0d