### PR TITLE
Adjust hero padding to raise quote

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -87,7 +87,7 @@ section::before {
     color: white;
     text-align: center;
     padding: 6rem 2rem; /* Increased padding for text content */
-    padding-top: calc(6rem + 260px); /* Offset content for fixed header */
+    padding-top: calc(6rem + 220px); /* Offset content for fixed header */
     margin-top: 0; /* Remove gap under navigation */
 }
 


### PR DESCRIPTION
## Summary
- Reduce top padding in hero section so the opening quote sits higher on the first image.

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689765ecd3408321a72b8a548cf97a25