### PR TITLE
Add Google review stars widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
 
     <section id="hero" class="hero">
         <h2 class="quote">&ldquo;Where Clean Spaces Inspire Fresh Starts.&rdquo;</h2>
+        <div id="google-rating" class="google-rating"></div>
         <p>Providing professional cleaning services for commercial businesses and residential homes.</p>
         <p><strong>Local, Licensed, and Insured!</strong></p>
         <a href="#contact" class="cta-button contact-link">Contact Us</a>

--- a/script.js
+++ b/script.js
@@ -178,3 +178,38 @@ if (reviewsWidget) {
     });
     observer.observe(reviewsWidget, { childList: true, subtree: true });
 }
+
+// Load Google rating and review count for the widget under the hero quote
+async function loadGoogleRating() {
+    const container = document.getElementById('google-rating');
+    if (!container) return;
+
+    const googleProfileUrl = 'https://www.google.com/maps/place/Elite+Clear+Services/';
+
+    function render(rating, reviews) {
+        const maxStars = 5;
+        let starsHtml = '';
+        for (let i = 1; i <= maxStars; i++) {
+            starsHtml += i <= Math.floor(rating)
+                ? '<i class="fas fa-star"></i>'
+                : '<i class="far fa-star"></i>';
+        }
+        container.innerHTML = `<a href="${googleProfileUrl}" target="_blank"><span class="rating-number">${rating.toFixed(1)}</span><span class="stars">${starsHtml}</span><span class="rating-count">(${reviews} Ratings & Reviews)</span></a>`;
+    }
+
+    try {
+        const apiKey = 'YOUR_API_KEY'; // Replace with your Google API key
+        const placeId = 'PLACE_ID'; // Replace with your Place ID
+        const url = `https://maps.googleapis.com/maps/api/place/details/json?place_id=${placeId}&fields=rating,user_ratings_total&key=${apiKey}`;
+        const response = await fetch(url);
+        if (!response.ok) throw new Error('Network response was not ok');
+        const data = await response.json();
+        if (data.status !== 'OK') throw new Error('API response not OK');
+        render(data.result.rating, data.result.user_ratings_total);
+    } catch (error) {
+        // Default to 5 stars and 14 reviews on failure
+        render(5, 14);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', loadGoogleRating);

--- a/styles.css
+++ b/styles.css
@@ -98,6 +98,43 @@ section::before {
     font-weight: bold;
 }
 
+/* Small Google rating widget centered under the quote */
+.google-rating {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 0.9rem;
+    margin-top: 0.5rem;
+    color: white;
+}
+
+.google-rating a {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+}
+
+.google-rating .rating-number {
+    margin-right: 0.25rem;
+    font-weight: bold;
+}
+
+.google-rating .stars {
+    display: flex;
+    margin: 0 0.25rem;
+}
+
+.google-rating .stars i {
+    color: #f4b400;
+    margin: 0 1px;
+}
+
+.google-rating .rating-count {
+    margin-left: 0.25rem;
+    font-size: 0.8rem;
+}
+
 /* Adding padding for motto space */
 .hero p {
     margin-top: 2rem; /* Add margin to space out the motto from nav links */


### PR DESCRIPTION
## Summary
- Add a small Google reviews star widget below the hero quote with rating number and count
- Style widget for centered display with filled and outlined stars
- Fetch rating data from Google with fallback to 5 stars and 14 reviews

## Testing
- `npm test` (fails: Could not read package.json: ENOENT)


------
https://chatgpt.com/codex/tasks/task_e_6898f5789ed083218551cc23f37825c7