### PR TITLE
Fix carousel navigation arrow placement on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -466,7 +466,13 @@ footer {
     .carousel-btn {
         width: 40px;
         height: 40px;
+    }
+
+    .prev-btn {
         left: 10px;
+    }
+
+    .next-btn {
         right: 10px;
     }
 }


### PR DESCRIPTION
## Summary
- Ensure carousel navigation arrows stay on their respective sides
- Add explicit left and right positions in mobile styles to prevent overlap

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/ECS/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a4fca72c48321908a106305021135